### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ please fork the code and submit a pull request.
 .. _rubicon-objc: https://github.com/pybee/rubicon-objc
 .. _rubicon-java: https://github.com/pybee/rubicon-java
 .. _BeeWare suite: http://pybee.org
-.. _Read The Docs: http://toga.readthedocs.org
+.. _Read The Docs: https://toga.readthedocs.io
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
 .. _BeeWare Users Mailing list: https://groups.google.com/forum/#!forum/beeware-users
 .. _BeeWare Developers Mailing list: https://groups.google.com/forum/#!forum/beeware-developers


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
